### PR TITLE
Fix namenode using wrong IPs for datanodes by using hostnames instead

### DIFF
--- a/config/core-site.xml
+++ b/config/core-site.xml
@@ -4,4 +4,8 @@
         <name>fs.defaultFS</name>
         <value>hdfs://hadoop-master:9000/</value>
     </property>
+    <property>
+        <name>dfs.client.use.datanode.hostname</name>
+        <value>true</value>
+    </property>
 </configuration>


### PR DESCRIPTION
For some reason namenodes were showing up in `hdfs dfsadmin -report` using wrong IP addresses which would explain the cluster's inability to store files. For example the report would show an IP of `10.0.0.100` for a datanode when really that node was running on `10.0.0.157`.

After reading [this stackoverflow post](https://stackoverflow.com/questions/32785256/hadoop-datanode-binds-wrong-ip-address) (and to some extend also [this one](https://stackoverflow.com/questions/33860478/why-is-dockerized-hadoop-datanode-registering-with-the-wrong-ip-address), although that seems to have been fixed) this appears to be some sort of networking problem were datanodes may be falsely detected to run on a gateways IP address.

Searching the Hadoop documentation, I came across an article about ["HDFS Support for Multihomed Networks"](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-hdfs/HdfsMultihoming.html) which recommends setting `dfs.client.use.datanode.hostname` on the namenode to use hostnames instead of IP addresses, implementing this fix seems to allow file uploads to the HDFS cluster.